### PR TITLE
add id field

### DIFF
--- a/vpm.json
+++ b/vpm.json
@@ -2,6 +2,7 @@
     "name": "meronmksTools",
     "author": "meronmks",
     "url": "https://meronmks.github.io/vpm-repos/vpm.json",
+    "id": "io.github.meronmks.vpm",
     "packages": {
         "com.meronmks.simpleudonpin":{
             "versions":{


### PR DESCRIPTION
VPMレポジトリを識別する id を追加します。

`meronmks.com` というドメインが存在しなかったため、githubのドメイン名を下にしたidを使用しました。